### PR TITLE
Fixed broken JSON when supplying channels

### DIFF
--- a/src/CMText/Message.php
+++ b/src/CMText/Message.php
@@ -161,7 +161,7 @@ class Message implements JsonSerializable
             $Channels
         );
 
-        $this->allowedChannels[] = array_values($supportedChannels);
+        $this->allowedChannels = array_unique(array_merge($this->allowedChannels, array_values($supportedChannels)));
 
         return $this;
     }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -1,7 +1,7 @@
 <?php
 require __DIR__ .'/../vendor/autoload.php';
 
-
+use CMText\Channels;
 use CMText\Message;
 
 class MessageTest extends PHPUnit_Framework_TestCase
@@ -121,4 +121,27 @@ class MessageTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * Tests if supplied channel is returned properly
+     */
+    public function testAllowedChannel()
+    {
+        $message = new Message();
+        $message->WithChannels([Channels::WHATSAPP]);
+
+        $json = $message->jsonSerialize();
+        $this->assertEquals($json->allowedChannels, [Channels::WHATSAPP]);
+    }
+
+    /**
+     * Tests if supplied channels are returned properly
+     */
+    public function testAllowedChannels()
+    {
+        $message = new Message();
+        $message->WithChannels([Channels::WHATSAPP, Channels::SMS]);
+
+        $json = $message->jsonSerialize();
+        $this->assertEquals($json->allowedChannels, [Channels::SMS, Channels::WHATSAPP]);
+    }
 }


### PR DESCRIPTION
This fixes a bug returning an array too deep when using `WithChannels()` method of `CMText\Message`.

Version 1.2.0:
```JSON
....
"allowedChannels": [
    ["WhatsApp"]
],
...
```

This hotfix:
```JSON
....
"allowedChannels": ["WhatsApp"],
...
```