### PR TITLE
Added WhatsApp message context

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "cmdotcom/text-sdk-php",
     "description": "PHP SDK to send messages with CM.com",
     "type": "library",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "keywords": ["sms","cm.com","rcs","whatsapp","viber","line","wechat","imessage","twitter","instagram"],
     "homepage": "https://www.cm.com/products/text/",
     "license": "MIT",

--- a/src/CMText/RichContent/Messages/ContactsMessage.php
+++ b/src/CMText/RichContent/Messages/ContactsMessage.php
@@ -3,6 +3,7 @@
 namespace CMText\RichContent\Messages;
 
 use CMText\RichContent\Common\Contact;
+use CMText\RichContent\Messages\WhatsApp\WhatsAppMessageContextTrait;
 
 /**
  * Class ContactsMessage
@@ -10,14 +11,16 @@ use CMText\RichContent\Common\Contact;
  */
 class ContactsMessage implements IRichMessage
 {
+    use WhatsAppMessageContextTrait;
+
     /**
-     * @var \CMText\RichContent\Common\Contact[]
+     * @var Contact[]
      */
     private $contacts = [];
 
     /**
      * ContactsMessage constructor.
-     * @param \CMText\RichContent\Common\Contact $Contact
+     * @param Contact $Contact
      */
     public function __construct(Contact $Contact)
     {
@@ -25,7 +28,7 @@ class ContactsMessage implements IRichMessage
     }
 
     /**
-     * @param \CMText\RichContent\Common\Contact $Contact
+     * @param Contact $Contact
      */
     public function addContact(Contact $Contact)
     {
@@ -38,9 +41,7 @@ class ContactsMessage implements IRichMessage
 	#[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
-        return (object)[
-            'contacts' => array_filter($this->contacts),
-        ];
+        return $this;
     }
 }
 

--- a/src/CMText/RichContent/Messages/ContactsMessage.php
+++ b/src/CMText/RichContent/Messages/ContactsMessage.php
@@ -16,7 +16,7 @@ class ContactsMessage implements IRichMessage
     /**
      * @var Contact[]
      */
-    private $contacts = [];
+    public $contacts = [];
 
     /**
      * ContactsMessage constructor.

--- a/src/CMText/RichContent/Messages/LocationPushMessage.php
+++ b/src/CMText/RichContent/Messages/LocationPushMessage.php
@@ -3,6 +3,7 @@
 namespace CMText\RichContent\Messages;
 
 use CMText\RichContent\Common\ViewLocationBase;
+use CMText\RichContent\Messages\WhatsApp\WhatsAppMessageContextTrait;
 
 /**
  * Class LocationPushMessage
@@ -10,10 +11,12 @@ use CMText\RichContent\Common\ViewLocationBase;
  */
 class LocationPushMessage implements IRichMessage
 {
+    use WhatsAppMessageContextTrait;
+
     /**
      * @var \CMText\RichContent\Common\ViewLocationBase Location to send.
      */
-    private $location;
+    public $location;
 
 
     /**
@@ -31,8 +34,6 @@ class LocationPushMessage implements IRichMessage
 	#[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
-        return (object)[
-            'location' => $this->location,
-        ];
+        return $this;
     }
 }

--- a/src/CMText/RichContent/Messages/MediaMessage.php
+++ b/src/CMText/RichContent/Messages/MediaMessage.php
@@ -2,17 +2,20 @@
 
 namespace CMText\RichContent\Messages;
 
+use CMText\RichContent\Messages\WhatsApp\WhatsAppMessageContextTrait;
+
 /**
  * Class MediaMessage
  * @package CMText\RichContent\Messages
  */
 class MediaMessage implements IRichMessage
 {
+    use WhatsAppMessageContextTrait;
 
     /**
      * @var \CMText\RichContent\Messages\MediaContent
      */
-    private $content;
+    public $media;
 
 
     /**
@@ -27,15 +30,13 @@ class MediaMessage implements IRichMessage
         string $Mimetype
     )
     {
-        $this->content = new MediaContent($Name, $Uri, $Mimetype);
+        $this->media = new MediaContent($Name, $Uri, $Mimetype);
     }
 
 
 	#[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
-        return (object)[
-            'media' => $this->content,
-        ];
+        return $this;
     }
 }

--- a/src/CMText/RichContent/Messages/TemplateMessage.php
+++ b/src/CMText/RichContent/Messages/TemplateMessage.php
@@ -2,11 +2,13 @@
 
 namespace CMText\RichContent\Messages;
 
+use CMText\RichContent\Messages\WhatsApp\WhatsAppMessageContextTrait;
 use CMText\RichContent\Templates\TemplateContentBase;
 
 
 class TemplateMessage implements IRichMessage
 {
+    use WhatsAppMessageContextTrait;
 
     public $template;
 

--- a/src/CMText/RichContent/Messages/TextMessage.php
+++ b/src/CMText/RichContent/Messages/TextMessage.php
@@ -2,23 +2,26 @@
 
 namespace CMText\RichContent\Messages;
 
+use CMText\RichContent\Messages\WhatsApp\WhatsAppMessageContextTrait;
+
 /**
  * Class TextMessage
  * @package CMText\RichContent\Messages
  */
 class TextMessage implements IRichMessage
 {
+    use WhatsAppMessageContextTrait;
 
     /**
      * @var string Body text of the message
      */
-    protected $text;
+    public $text;
 
 
     /**
      * @var string Instagram message tag (optional)
      */
-    protected $tag;
+    public $tag;
 
 
     /**
@@ -26,7 +29,7 @@ class TextMessage implements IRichMessage
      * @param string $Text
      * @param string $Tag
      */
-    public function __construct(string $Text, string $Tag = '')
+    public function __construct(string $Text, string $Tag = null)
     {
         $this->text = $Text;
         $this->tag = $Tag;
@@ -36,9 +39,6 @@ class TextMessage implements IRichMessage
 	#[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
-        return (object)array_filter([
-            'text' => $this->text,
-            'tag' => $this->tag
-        ]);
+        return $this;
     }
 }

--- a/src/CMText/RichContent/Messages/WhatsApp/WhatsAppInteractiveMessage.php
+++ b/src/CMText/RichContent/Messages/WhatsApp/WhatsAppInteractiveMessage.php
@@ -6,6 +6,8 @@ use CMText\RichContent\Messages\IRichMessage;
 
 class WhatsAppInteractiveMessage implements IRichMessage
 {
+    use WhatsAppMessageContextTrait;
+
     /**
      * @var WhatsAppInteractiveContent
      */

--- a/src/CMText/RichContent/Messages/WhatsApp/WhatsAppMessageContext.php
+++ b/src/CMText/RichContent/Messages/WhatsApp/WhatsAppMessageContext.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace CMText\RichContent\Messages\WhatsApp;
+
+class WhatsAppMessageContext
+{
+    /**
+     * @var $message_id string Message ID to which the current message is a reply
+     */
+    public $message_id;
+}

--- a/src/CMText/RichContent/Messages/WhatsApp/WhatsAppMessageContextTrait.php
+++ b/src/CMText/RichContent/Messages/WhatsApp/WhatsAppMessageContextTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace CMText\RichContent\Messages\WhatsApp;
+
+/**
+ * Contextual properties of the message.
+ * Currently only applicable to <see cref="Channel.WhatsApp" />
+ * Docs: https://developers.cm.com/messaging/docs/whatsapp-inbound#mt-replies-mo
+ */
+trait WhatsAppMessageContextTrait
+{
+    /**
+     * @var $context WhatsAppMessageContext
+     */
+    public $context;
+}

--- a/src/CMText/TextClient.php
+++ b/src/CMText/TextClient.php
@@ -32,7 +32,7 @@ class TextClient implements ITextClient
     /**
      * SDK Version constant
      */
-    const VERSION = '3.0.0';
+    const VERSION = '3.0.1';
 
 
     /**


### PR DESCRIPTION
This is a feature to keep messages in the same WhatsApp Conversation.

Read about it here : https://developers.cm.com/messaging/docs/whatsapp-inbound#mt-replies-mo

It was recently implemented in the dotnet version of our SDK so this one can not stay behind.